### PR TITLE
Fix compilation errors on newer DPDK versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Minimal examples of DPDK
 
 ## minimal_tx
-Minimal code to send one UDP packet with DPDK
+Minimal code to send UDP packets with DPDK
 
 ## minimal_rx
 Minimal code to receive packets with DPDK

--- a/minimal_rx/minimal_rx.c
+++ b/minimal_rx/minimal_rx.c
@@ -21,9 +21,12 @@
 #define MBUF_CACHE_SIZE 250
 #define BURST_SIZE 32
 
+void DumpHex(const void*, size_t);
+void rx_packets(void);
+
 static const struct rte_eth_conf port_conf_default = {
 	.rxmode = {
-		.max_rx_pkt_len = ETHER_MAX_LEN,
+		.max_rx_pkt_len = RTE_ETHER_MAX_LEN,
 	},
 };
 
@@ -32,9 +35,9 @@ void DumpHex(const void* data, size_t size) {
 	size_t i, j;
 	ascii[16] = '\0';
 	for (i = 0; i < size; ++i) {
-		printf("%02X ", ((unsigned char*)data)[i]);
-		if (((unsigned char*)data)[i] >= ' ' && ((unsigned char*)data)[i] <= '~') {
-			ascii[i % 16] = ((unsigned char*)data)[i];
+		printf("%02X ", ((const unsigned char*)data)[i]);
+		if (((const unsigned char*)data)[i] >= ' ' && ((const unsigned char*)data)[i] <= '~') {
+			ascii[i % 16] = ((const unsigned char*)data)[i];
 		} else {
 			ascii[i % 16] = '.';
 		}
@@ -96,7 +99,7 @@ port_init(uint16_t port, struct rte_mempool *mbuf_pool)
 		return retval;
 
 	/* Display the port MAC address. */
-	struct ether_addr addr;
+	struct rte_ether_addr addr;
 	rte_eth_macaddr_get(port, &addr);
 	printf("Port %u MAC: %02" PRIx8 " %02" PRIx8 " %02" PRIx8
 			   " %02" PRIx8 " %02" PRIx8 " %02" PRIx8 "\n",

--- a/minimal_tx/minimal_tx.c
+++ b/minimal_tx/minimal_tx.c
@@ -171,7 +171,7 @@ static void send_packet(void)
 	struct rte_mbuf *pkts_burst[1];
 
 	pkt = rte_mbuf_raw_alloc(mbuf_pool);
-        if(pkt == NULL) {printf("trouble at rte_mbuf_raw_alloc\n");}
+        if(pkt == NULL) {printf("trouble at rte_mbuf_raw_alloc\n"); return;}
         rte_pktmbuf_reset_headroom(pkt);
         pkt->data_len = TX_PACKET_LENGTH;
 	

--- a/minimal_tx/minimal_tx.c
+++ b/minimal_tx/minimal_tx.c
@@ -199,6 +199,7 @@ static void send_packet(void)
 	pkts_burst[0] = pkt;
         const uint16_t nb_tx = rte_eth_tx_burst(0, 0, pkts_burst, 1);
 	packet_count += nb_tx;
+	rte_mbuf_raw_free(pkt);
 }
 
 // Initialize Port

--- a/minimal_tx/minimal_tx.c
+++ b/minimal_tx/minimal_tx.c
@@ -269,7 +269,7 @@ static void exit_stats(int sig)
 	printf("Total packets: %lu\n", packet_count);
 	printf("Total transmission time: %ld seconds\n", total_time);
 	printf("Average transmission rate: %lu pps\n", packet_count / total_time);
-	printf("                           %lu Gpbs\n", ((packet_count * TX_PACKET_LENGTH * 8) / total_time) / 1000000000);
+	printf("                           %lu Gbps\n", ((packet_count * TX_PACKET_LENGTH * 8) / total_time) / 1000000000);
 	printf("=======================================\n");
 	exit(0);
 }

--- a/minimal_tx/minimal_tx.c
+++ b/minimal_tx/minimal_tx.c
@@ -269,7 +269,7 @@ static void exit_stats(int sig)
 	printf("Total packets: %lu\n", packet_count);
 	printf("Total transmission time: %ld seconds\n", total_time);
 	printf("Average transmission rate: %lu pps\n", packet_count / total_time);
-	printf("                           %lu Gbps\n", ((packet_count * TX_PACKET_LENGTH * 8) / total_time) / 1000000000);
+	printf("                           %lu Mbps\n", ((packet_count * TX_PACKET_LENGTH * 8) / total_time) / 1000000);
 	printf("=======================================\n");
 	exit(0);
 }
@@ -279,7 +279,8 @@ int main(int argc, char **argv)
 	int ret,c;
 	uint16_t pkt_data_len;
 	int mac_flag=0,ip_src_flag=0,ip_dst_flag=0;
-	
+	int counter = 0;
+
 	ret = rte_eal_init(argc, argv);
 	if (ret < 0)
 		rte_panic("Cannot init EAL\n");
@@ -344,8 +345,13 @@ int main(int argc, char **argv)
         setup_pkt_udp_ip_headers(&pkt_ip_hdr, &pkt_udp_hdr, pkt_data_len);
 
 	t1 = time(NULL);
-	while (true)
+	while (true) {
+		counter++;
+		if (counter % 35 == 0) {
+			usleep(1);
+		}
 		send_packet();
+	}
 
 	return(0);
 }


### PR DESCRIPTION
The existing code doesn't compile with newer versions of DPDK. Some data type names were changed. Also fix compilation warnings since -Wall compiler option is set.